### PR TITLE
Make WebKit-based browsers set cookies on redirect in more cases, fixes #11

### DIFF
--- a/authomatic/core.py
+++ b/authomatic/core.py
@@ -352,12 +352,17 @@ class Session(object):
             Expires value will be ``Thu, 01-Jan-1970 00:00:01 GMT``.
         """
 
-        template = '{name}={value}; Domain={domain}; Path={path}; HttpOnly{secure}{expires}'
-
         value = 'deleted' if delete else self._serialize(self.data)
 
         split_url = urlparse.urlsplit(self.adapter.url)
         domain = split_url.netloc.split(':')[0]
+
+        # Work-around for issue #11, failure of WebKit-based browsers to accept
+        # cookies set as part of a redirect response in some circumstances.
+        if not '.' in domain:
+            template = '{name}={value}; Path={path}; HttpOnly{secure}{expires}'
+        else:
+            template = '{name}={value}; Domain={domain}; Path={path}; HttpOnly{secure}{expires}'
 
         return template.format(name=self.name,
                                value=value,


### PR DESCRIPTION
Bit of a nasty hack, but a lesser evil of other successful work-arounds I tried.

This works for me with Chrome 28 on Mac OS X, but I haven't yet tested beyond this browser.
