### PR TITLE
Access user data automatically if an OAuth2 login flow does not provide any

### DIFF
--- a/authomatic/providers/oauth2.py
+++ b/authomatic/providers/oauth2.py
@@ -351,7 +351,12 @@ class OAuth2(providers.AuthorizationProvider):
             
             # create user
             self._update_or_create_user(response.data, self.credentials)
-            
+
+            # Access user data from provider if we don't yet have a valid user,
+            # i.e. one with at least a non-empty `id`
+            if self.user and not self.user.id:
+                self.user.update()
+
             #===================================================================
             # We're done!
             #===================================================================


### PR DESCRIPTION
The Authomatic API generally returns a populated User object from a login
authentication flow, except for OAuth2 providers (e.g. Facebook) for which
an addition user data lookup request is required.

With this change, a User data update is performed automatically if necessary
to populate the User object with useful information.
