### PR TITLE
Use Provider's default `identifier` if no "id" param given.

### DIFF
--- a/authomatic/providers/__init__.py
+++ b/authomatic/providers/__init__.py
@@ -892,11 +892,15 @@ class AuthenticationProvider(BaseProvider):
     def __init__(self, *args, **kwargs):   
         super(AuthenticationProvider, self).__init__(*args, **kwargs)
         
+        # Lookup default identifier, if available in provider
+        default_identifier = getattr(self, 'identifier', None)
+
         # Allow for custom name for the "id" querystring parameter.
         self.identifier_param = kwargs.get('identifier_param', 'id')
         
-        # Get the identifier from request params.
-        self.identifier = self.params.get(self.identifier_param)
+        # Get the identifier from request params, or use default as fallback.
+        self.identifier = self.params.get(
+            self.identifier_param, default_identifier)
         
 
 PROVIDER_ID_MAP = [BaseProvider, AuthorizationProvider, AuthenticationProvider]

--- a/authomatic/providers/openid.py
+++ b/authomatic/providers/openid.py
@@ -363,7 +363,7 @@ class OpenID(providers.AuthenticationProvider):
             elif response.status == consumer.FAILURE:
                 raise FailureError(response.message)
             
-        elif self.params.get(self.identifier_param):
+        elif self.identifier:  # As set in AuthenticationProvider.__init__
             #===================================================================
             # Phase 1 before redirect
             #===================================================================


### PR DESCRIPTION
Upon init of OpenID provider objects, the predefined `identifier` value
that may be present in specific provider classes like Yahoo and Google
was being clobbered by the parameter lookup if no "id" (or similar)
parameter was provided.

Also modified flow logic to use the provider object's `identifier` field
instead of always requiring an "id" (or similar) request parameter.
