### PR TITLE
Ensure deserialization of session data always returns non-None object.

### DIFF
--- a/authomatic/core.py
+++ b/authomatic/core.py
@@ -406,6 +406,9 @@ class Session(object):
 
         if not self._data:
             self._data = self._get_data()
+        # Always return a dict, even if deserialization returned nothing
+        if self._data is None:
+            self._data = {}
         return self._data
 
 


### PR DESCRIPTION
When deserializing invalid session data, such as an expired session,
the `_get_data()` method sometimes returns None. This fix ensures that
the `data` property always returns an empty dict instead of None in this
and all cases, to avoid breaking subsequent get lookups of the session
data.
