### PR TITLE
Allow customizing the HTTP method of requesting the access token

### DIFF
--- a/authomatic/providers/oauth2.py
+++ b/authomatic/providers/oauth2.py
@@ -54,6 +54,8 @@ class OAuth2(providers.AuthorizationProvider):
     #: :class:`bool` If ``False``, the provider doesn't support CSRF protection.
     supports_csrf_protection = True
     
+    token_request_method = 'POST'  # method for requesting an access token
+    
     def __init__(self, *args, **kwargs):
         """
         Accepts additional keyword arguments:
@@ -315,7 +317,7 @@ class OAuth2(providers.AuthorizationProvider):
             request_elements = self.create_request_elements(request_type=self.ACCESS_TOKEN_REQUEST_TYPE,
                                                              credentials=self.credentials,
                                                              url=self.access_token_url,
-                                                             method='POST',
+                                                             method=self.token_request_method,
                                                              redirect_uri=self.url,
                                                              params=self.access_token_params,
                                                              headers=self.access_token_headers)
@@ -772,6 +774,9 @@ class LinkedIn(OAuth2):
                     '(id,first-name,last-name,formatted-name,location,picture-url,public-profile-url,email-address,date-of-birth,phone-numbers)?format=json'
     
     user_info_scope = ['r_fullprofile', 'r_emailaddress', 'r_contactinfo']
+    
+    token_request_method = 'GET'  # To avoid a bug with OAuth2.0 on Linkedin
+    # http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token
     
     @classmethod
     def _x_request_elements_filter(cls, request_type, request_elements, credentials):


### PR DESCRIPTION
Fixes a [Linkedin OAuth2 issue](http://developer.linkedin.com/forum/unauthorized-invalid-or-expired-token-immediately-after-receiving-oauth2-token)

If LinkedIn finally fixes this bug this PR is not needed.
