### PR TITLE
Added requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ python-openid
 liveandletdie
 pytest
 selenium
+ez_install
+google-appengine


### PR DESCRIPTION
This is a small fork, but necessary for the django example application to run. ez_install is required for google-appengine. google-appengine is just the Google Python SDK through pip since Google doesn't offer it there. 
