### PR TITLE
Fix bug for old Yahoo! profiles

### DIFF
--- a/authomatic/providers/oauth1.py
+++ b/authomatic/providers/oauth1.py
@@ -782,9 +782,14 @@ class Yahoo(OAuth1):
         
         user.picture = _user.get('image', {}).get('imageUrl')
         
-        user.city, user.country = _user.get('location', ',').split(',')
-        user.city = user.city.strip()
-        user.country = user.country.strip()
+        try:
+            user.city, user.country = _user.get('location', ',').split(',')
+            user.city = user.city.strip()
+            user.country = user.country.strip()
+        except ValueError:
+            # probably user hasn't activated Yahoo Profile
+            user.city = None
+            user.country = None
         
         _date = _user.get('birthdate')
         _year = _user.get('birthYear')


### PR DESCRIPTION
If the user who was trying to authenticate/login hasn't activated the Yahoo Profile (i.e., has an old/unused Yahoo account), the Authomatic.user.update() method was returning an error (probably because old profiles don't have location data):

```
File "../lib/python2.7/site-packages/authomatic/providers/oauth1.py", line 785, in _x_user_parser
    user.city, user.country = _user.get('location', ',').split(',')
ValueError: need more than 1 value to unpack
```

I fix the bug with a try/exception clause to avoid impeding the authentication due to the lack of a comma in the location info Yahoo was sending.
