### PR TITLE
Add support for user email in Bitbucket provider

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ Unreleased
 ----------
 
 * Adjusted naming of default scope for :class:`.oauth2.Facebook` to Facebook v2 API
+* Added support for :attr:`.User.email` to the :class:`.oauth1.Bitbucket` provider.
 
 
 Version 0.1.0


### PR DESCRIPTION
Adds support for BitBucket email property by fetching available emails and selecting one marked as primary.
