### PR TITLE
Fix Twitter user info endpoint

### DIFF
--- a/authomatic/providers/oauth1.py
+++ b/authomatic/providers/oauth1.py
@@ -825,7 +825,7 @@ class Twitter(OAuth1):
     request_token_url = 'https://api.twitter.com/oauth/request_token'
     user_authorization_url = 'https://api.twitter.com/oauth/authenticate'
     access_token_url = 'https://api.twitter.com/oauth/access_token'
-    user_info_url = 'https://api.twitter.com/1.1/account/verify_credentials.json'
+    user_info_url = 'https://api.twitter.com/1.1/account/verify_credentials.json?include_entities=true'
     
     supports_jsonp = True
      


### PR DESCRIPTION
profile_image_url is missing from the response unless we provide parameter include_entities=true
