### PR TITLE
Explicitly request FB fields.

### DIFF
--- a/authomatic/providers/oauth2.py
+++ b/authomatic/providers/oauth2.py
@@ -869,6 +869,14 @@ class Facebook(OAuth2):
         return True
 
 
+    def access(self, url, params=None, **kwargs):
+        if params is None:
+            params = {}
+        params['fields'] = 'id,first_name,last_name,picture,email,gender,timezone,location,birthday,locale'
+
+        return super(Facebook, self).access(url, params, **kwargs)
+
+
 class Foursquare(OAuth2):
     """
     Foursquare |oauth2| provider.


### PR DESCRIPTION
A simple update to explicitly request fields from facebook. (Fixes #130)

This PR only requests fields that were previously provided implicitly. Requesting 'new' fields should be a separate feature PR.