### PR TITLE
Request email from Twitter. Fixes #140.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Unreleased
 ----------
 
+* Add :attr: email to :class: `oauth1.Twitter` provider.
 * Fix Twitter user info endpoint to include image url.
 * Support passing of user state in oauth2 to support variable redirect urls.
 * The :class:`.oauth2.Google` provider now uses

--- a/authomatic/providers/oauth1.py
+++ b/authomatic/providers/oauth1.py
@@ -809,6 +809,7 @@ class Twitter(OAuth1):
 
     Supported :class:`.User` properties:
 
+    * email
     * id
     * link
     * locale
@@ -822,7 +823,6 @@ class Twitter(OAuth1):
     * birth_date
     * city
     * country
-    * email
     * gender
     * first_name
     * last_name
@@ -835,6 +835,7 @@ class Twitter(OAuth1):
 
     supported_user_attributes = core.SupportedUserAttributes(
         id=True,
+        email=True,
         link=True,
         locale=True,
         location=True,
@@ -846,7 +847,7 @@ class Twitter(OAuth1):
     request_token_url = 'https://api.twitter.com/oauth/request_token'
     user_authorization_url = 'https://api.twitter.com/oauth/authenticate'
     access_token_url = 'https://api.twitter.com/oauth/access_token'
-    user_info_url = 'https://api.twitter.com/1.1/account/verify_credentials.json?include_entities=true'
+    user_info_url = 'https://api.twitter.com/1.1/account/verify_credentials.json?include_entities=true&include_email=true'
     
     supports_jsonp = True
      


### PR DESCRIPTION
Add `include_email=True` url param to request emails form twitter as requested in #140. Twitter reference: https://dev.twitter.com/rest/reference/get/account/verify_credentials