### PR TITLE
Create tutorial for providers

### DIFF
--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -9,3 +9,4 @@ Tutorials / Examples
    pyramid-simple
    simple
    credentials
+   providers

--- a/doc/source/examples/providers.rst
+++ b/doc/source/examples/providers.rst
@@ -1,8 +1,99 @@
 |oauth2| Provider Implementation Tutorial
 -----------------------------------------
 
+Activate the virtual environment ``./venv``.
 
-#. Copy the expected values template.
+.. code-block:: bash
+
+    $ . ./venv/bin/activate
+
+Add the new provider to functional tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Change directory to ``./tests/functional_tests/``.
+
+.. code-block:: bash
+
+    $(venv) cd ./tests/functional_tests/
+
+Create the *expected values* module for the new provider by copying the
+``tests/functional_tests/expected_values/new_provider.py.template`` file to
+``tests/functional_tests/expected_values/eventbrite.py``.
+
+.. code-block:: bash
+
+    $(venv) cp expected_values/new_provider.py.template expected_values/eventbrite.py
+
+Create the functional tests config from the template
+``tests/functional_tests/config-template.py``.
+
+.. code-block:: bash
+
+    $(venv) cp config-template.py config.py
+
+Add a new provider slug to the ``INCLUDE_PROVIDERS`` list in the config in
+correct alphabetical order and comment out all the other providers.
+
+.. code-block:: python
+
+    # tests/functional_tests/config.py
+
+    # Only providers included here will be tested.
+    # This is a convenience to easily exclude providers from tests by commenting
+    # them out.
+    INCLUDE_PROVIDERS = [
+        # 'behance',
+        # 'bitly',
+        # 'deviantart',
+        'eventbrite',
+        # 'facebook',
+        # 'foursquare',
+        # 'google',
+        # 'github',
+        # 'linkedin',
+        # 'paypal',
+        # 'reddit',
+        # 'vk',
+        # 'windowslive',
+        # 'yammer',
+        # 'yandex',
+    ]
+
+Run the test. Make sure that you have the virtual environment active.
+
+.. code-block:: bash
+
+    $(venv) py.test -vv
+
+The test should fail with the
+``No record for the provider "provider_slug" was not found in the config!``
+exception. Replace the ``'provider_slug'`` value on line 7 with the slug of the
+new provider.
+
+.. code-block:: python
+
+    # tests/functional_tests/expected_values/eventbrite.py
+
+    # (...)
+
+    conf = fixtures.get_configuration('eventbrite')
+
+Run the test again.
+
+.. code-block:: bash
+
+    $(venv) py.test -vv
+
+It should fail again, this time with this exception:
+``No record for the provider "eventbrite" was not found in the config!``.
+We need to add a record for the new provider to the actual config dictionary.
+
+
+
+
+
+
+
 #. Register by the provider and fill out ALL possible user profile fields.
 #. Register an |oauth2| application by the provider.
 #. Find the |oauth2| flow and user info endpoints in the provider's API documentation.

--- a/doc/source/examples/providers.rst
+++ b/doc/source/examples/providers.rst
@@ -1,0 +1,29 @@
+|oauth2| Provider Implementation Tutorial
+-----------------------------------------
+
+
+#. Copy the expected values template.
+#. Register by the provider and fill out ALL possible user profile fields.
+#. Register an |oauth2| application by the provider.
+#. Find the |oauth2| flow and user info endpoints in the provider's API documentation.
+#. Make a domain alias for localhost.
+#. Launch the ``./examples/flask/functional_test`` application.
+#. Create a new class for the provider.
+#. Override the |oauth2| enpoints.
+#. Add the provider to functional tests.
+  #. Add an entry to the functional tests config.
+  #. Comment out all other providers in the ``INCLUDE_PROVIDERS`` list.
+    #. Refresh the functional tests app and click on the link of the new provider.
+        #. On the consent page open the browser inspector and copy the login,
+           password and consent button(s) xpaths to the expected values file.
+        #. If there was a problem debug, identify the problem and handle it in the
+           ``_x_credentials_parser()`` method.
+        #. If everything went good there should be a syntax highlighted json response.
+        #. If the json response has any properties which were not automatically parsed
+           to the user object you need to override the ``_x_user_parser()`` method.
+  #. Stop the functional tests app.
+  #. Run ``py.test -vv tests/functional_tests``
+  #. A Firefox window should open and the tests should fill out the consent form
+     and hit the consent button.
+#. Add the provider's |oauth2|, API and app dashboard links if any to the
+   docstring.

--- a/tests/functional_tests/expected_values/new_provider.py.template
+++ b/tests/functional_tests/expected_values/new_provider.py.template
@@ -1,0 +1,111 @@
+import fixtures
+import constants
+# from authomatic.providers import oauth1
+# from authomatic.providers import oauth2
+
+
+conf = fixtures.get_configuration('provider_slug')
+
+CONFIG = {
+    'login_xpath': '',
+    'password_xpath': '',
+    'consent_xpaths': [
+        ''
+    ],
+    'class_': ProviderClass,
+    'scope': ProviderClass.user_info_scope,
+    'user': {
+        'birth_date': conf.user_birth_date,
+        'city': conf.user_city,
+        'country': conf.user_country,
+        'email': conf.user_email,
+        'first_name': conf.user_first_name,
+        'gender': conf.user_gender,
+        'id': conf.user_id,
+        'last_name': conf.user_last_name,
+        'link': conf.user_link,
+        'locale': conf.user_locale,
+        'name': conf.user_name,
+        'nickname': conf.user_nickname,
+        'phone': conf.user_phone,
+        'picture': conf.user_picture,
+        'postal_code': conf.user_postal_code,
+        'timezone': conf.user_timezone,
+        'username': conf.user_username_reverse,
+    },
+    'content_should_contain': [
+        conf.user_birth_date,
+        conf.user_city,
+        conf.user_country,
+        conf.user_email,
+        conf.user_first_name,
+        conf.user_gender,
+        conf.user_id,
+        conf.user_last_name,
+        conf.user_link,
+        conf.user_locale,
+        conf.user_name,
+        conf.user_nickname,
+        conf.user_phone,
+        conf.user_picture,
+        conf.user_postal_code,
+        conf.user_timezone,
+        conf.user_username_reverse,
+
+        # User info response JSON keys
+        'foo', 'bar', 'baz',
+    ],
+    # Case insensitive
+    'content_should_not_contain':
+        [] +
+        # conf.email_escaped +
+        # conf.no_birth_date +
+        # conf.no_city +
+        # conf.no_email +
+        # conf.no_first_name +
+        # conf.no_gender +
+        # conf.no_last_name +
+        # conf.no_locale +
+        # conf.no_nickname +
+        # conf.no_phone +
+        # conf.no_postal_code +
+        # conf.no_timezone +
+        # conf.no_username +
+        # conf.no_location +
+        ['any', 'other', 'values'],
+
+    # True means that any thruthy value is expected
+    'credentials': {
+        'token_type': True,
+        'provider_type_id': '#-#',
+        '_expiration_time': True,
+        'consumer_key': True,
+        'provider_id': True,
+        'consumer_secret': True,
+        'token': True,
+        'token_secret': True,
+        '_expire_in': True,
+        'provider_name': 'provider_name',
+        'refresh_token': True,
+        'provider_type': 'provider_type',
+        'refresh_status': constants.CREDENTIALS_REFRESH_OK,
+    },
+    # Testing changes after credentials refresh
+    # same: True
+    # not same: False
+    # don't test: None
+    'credentials_refresh_change': {
+        'token_type': True,
+        'provider_type_id': True,
+        '_expiration_time': True,
+        'consumer_key': True,
+        'provider_id': True,
+        'consumer_secret': True,
+        'token': True,
+        'token_secret': True,
+        '_expire_in': True,
+        'provider_name': True,
+        'refresh_token': True,
+        'provider_type': True,
+    },
+}

--- a/tests/functional_tests/fixtures/__init__.py
+++ b/tests/functional_tests/fixtures/__init__.py
@@ -122,7 +122,8 @@ def get_configuration(provider):
 ASSEMBLED_CONFIG = {}
 expected_values_path = path.dirname(expected_values.__file__)
 
-# Loop through all modules of the expected_values package.
+# Loop through all modules of the expected_values package
+# except the _template.py
 for importer, name, ispkg in pkgutil.iter_modules([expected_values_path]):
     # Import the module
     mod = importer.find_module(name).load_module(name)

--- a/tests/functional_tests/fixtures/__init__.py
+++ b/tests/functional_tests/fixtures/__init__.py
@@ -88,7 +88,11 @@ def get_configuration(provider):
     # Merge and override common settings with provider settings.
     conf = {}
     conf.update(config.COMMON)
-    conf.update(config.PROVIDERS[provider])
+    try:
+        conf.update(config.PROVIDERS[provider])
+    except KeyError:
+        raise Exception('No record for the provider "{0}" was not found in the '
+                        'config!'.format(provider))
 
     class_name = '{0}Configuration'.format(provider.capitalize())
     Res = namedtuple(class_name, sorted(conf.keys()))


### PR DESCRIPTION
It looks like this branch has never been merged into master, though its content is found in the generated docs at gh-pages and on the live docs: https://authomatic.github.io/authomatic/examples/providers.html