### PR TITLE
Fix ReST replace relative path.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -83,7 +83,7 @@ rst_prolog = """
 .. |async| replace:: The internal implementation of the future pattern is quite naive. Use with caution!
 
 .. |provider-class| replace:: provider class
-.. _provider-class: /reference/providers
+.. _provider-class: providers
 
 
 .. |no-csrf| replace:: This provider doesn't support CSRF protection!


### PR DESCRIPTION
Fix the incorrect absolute path `/reference/providers` and use the correct relative path `providers` in ReST replace 'alias' `provider_class`

Replaces #98 (which was an equivalent edit to the generated html output).