### PR TITLE
Enable Pyramid framework with SSL.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ addons:
   - authomatic.com
   - authomatic.org
 install:
-- sudo pip install tox
+- pip install tox
 script:
-- sudo tox -e py3
+# Call tox from venv, not system
+- sudo $VIRTUAL_ENV/bin/tox -e py3
 after_failure:
 - tail -n 500 tests/functional_tests/*.log
 - tail -n 500 flask.log

--- a/tests/functional_tests/config_public.py
+++ b/tests/functional_tests/config_public.py
@@ -21,7 +21,8 @@ def get_browser():
 
     options = webdriver.ChromeOptions()
     options.add_argument("--no-sandbox")
-    options.add_argument("--disable-dev-shm-usage");
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--ignore-certificate-errors")
     options.add_experimental_option("useAutomationExtension", False);
     return webdriver.Chrome(options=options)
 
@@ -56,7 +57,7 @@ HOST_ALIAS = 'authomatic.org'
 INCLUDE_FRAMEWORKS = [
     # 'django',
     'flask',  # Runs with https
-    # 'pyramid',
+    'pyramid',  # Runs with https
 ]
 
 # Only providers included here will be tested.

--- a/tests/functional_tests/expected_values/twitter.py
+++ b/tests/functional_tests/expected_values/twitter.py
@@ -31,6 +31,7 @@ CONFIG = {
     'consent_xpaths': ['//*[@id="allow"]'],
     'after_login_hook': after_login_hook,
     'class_': oauth1.Twitter,
+    'logout_url': 'https://twitter.com/logout',
     'user': {
         'birth_date': None,
         'city': conf.user_city,

--- a/tests/functional_tests/test_providers.py
+++ b/tests/functional_tests/test_providers.py
@@ -63,7 +63,8 @@ ALL_APPS = {
         os.path.join(EXAMPLES_DIR, 'pyramid/functional_test/main.py'),
         host=config.HOST,
         port=config.PORT,
-        check_url=config.HOST_ALIAS
+        check_url=config.HOST_ALIAS,
+        ssl=True,
     ),
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,14 @@ skipsdist=true
 [testenv]
 # chromedriver-binary version must be kept in step with installed google-chrome version
 deps=
-    chromedriver-binary==78.0.3904.105.0
+    chromedriver-binary==80.0.3987.16.0
     flask
     pycodestyle
     pylint
     pyramid
     pytest
     selenium
-    liveandletdie>=0.0.6
+    liveandletdie
     pyopenssl
     pyvirtualdisplay
     py27: django


### PR DESCRIPTION
This PR re-enables the `pyramid` framework in testing, using the new release of `liveandletdie` which provides SSL support.

It also instructs `selenium`/`chrome` to ignore certificate errors, logs out of travis between frameworks, and tidies up some of the `travis`/`tox` config.