### PR TITLE
docs: Fix simple typo, visibile -> visible

### DIFF
--- a/examples/gae/showcase/static/js/foundation/foundation.forms.js
+++ b/examples/gae/showcase/static/js/foundation/foundation.forms.js
@@ -320,7 +320,7 @@
 
     hidden_fix : {
       /**
-       * Sets all hidden parent elements and self to visibile.
+       * Sets all hidden parent elements and self to visible.
        *
        * @method adjust
        * @param {jQuery Object} $child


### PR DESCRIPTION
There is a small typo in examples/gae/showcase/static/js/foundation/foundation.forms.js.

Should read `visible` rather than `visibile`.

