### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Features
 * **Framework agnostic** thanks to adapters.
   Out of the box support for **Django**, **Flask**, **Pyramid** and **Webapp2**.
 * Ready to accommodate future authorization/authentication protocols.
-* Makes provider API callls a breeze.
+* Makes provider API calls a breeze.
 * Asynchronous requests.
 * JavaScript library as a bonus.
 * Out of the box support for:

--- a/doc/source/development.rst
+++ b/doc/source/development.rst
@@ -94,7 +94,7 @@ Compile the documentation with this commands:
    (py27)$ make html
 
 The documentation will be compiled to ``./doc/build/html``.
-For easy deploiment to `Github Pages <https://pages.github.com/>`__,
+For easy deployment to `Github Pages <https://pages.github.com/>`__,
 the ``./doc/build/html`` directory is actually a clone of the **origin** of the
 actual project repository that you cloned from (your fork) with the
 **gh-pages** branch checked out.

--- a/examples/flask/functional_test/main.py
+++ b/examples/flask/functional_test/main.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     # file_handler.setLevel(logging.WARNING)
     app.logger.addHandler(file_handler)
 
-    # This does nothing unles you run this module with --testliveserver flag.
+    # This does nothing unless you run this module with --testliveserver flag.
     import liveandletdie
     liveandletdie.Flask.wrap(app)
 

--- a/examples/gae/showcase/static/js/foundation/foundation.forms.js
+++ b/examples/gae/showcase/static/js/foundation/foundation.forms.js
@@ -235,7 +235,7 @@
         $customSelect.addClass( 'open' );
         //
         // Quickly, display all parent elements.
-        // This should help us calcualate the width of the list item's within the drop down.
+        // This should help us calculate the width of the list item's within the drop down.
         //
         var self = Foundation.libs.forms;
         self.hidden_fix.adjust( $customList );

--- a/examples/gae/showcase/static/js/foundation/foundation.joyride.js
+++ b/examples/gae/showcase/static/js/foundation/foundation.joyride.js
@@ -103,7 +103,7 @@
 
       if (!this.settings.init) this.init();
       
-      // non configureable settings
+      // non configurable settings
       this.settings.$content_el = $this;
       this.settings.body_offset = $(this.settings.tipContainer).position();
       this.settings.$tip_content = this.settings.$content_el.find('> li');

--- a/tests/functional_tests/expected_values/windowslive.py
+++ b/tests/functional_tests/expected_values/windowslive.py
@@ -56,7 +56,7 @@ CONFIG = {
     # Case insensitive
     'content_should_not_contain':
         conf.no_birth_date +
-        # conf.no_gender + # Gender JSON key is there but is alwas null
+        # conf.no_gender + # Gender JSON key is there but is always null
         [constants.GENDER_MALE] +
         conf.no_location +
         conf.no_nickname +


### PR DESCRIPTION
There are small typos in:
- README.rst
- doc/source/development.rst
- examples/flask/functional_test/main.py
- examples/gae/showcase/static/js/foundation/foundation.forms.js
- examples/gae/showcase/static/js/foundation/foundation.joyride.js
- tests/functional_tests/expected_values/windowslive.py

Fixes:
- Should read `unless` rather than `unles`.
- Should read `deployment` rather than `deploiment`.
- Should read `configurable` rather than `configureable`.
- Should read `calls` rather than `callls`.
- Should read `calculate` rather than `calcualate`.
- Should read `always` rather than `alwas`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md