### PR TITLE
ssl cert_file has been replaced with contexts. Fixes #235.

### DIFF
--- a/authomatic/providers/__init__.py
+++ b/authomatic/providers/__init__.py
@@ -451,12 +451,14 @@ class BaseProvider(object):
 
         # Connect
         if url_parsed.scheme.lower() == 'https':
-            context = None if ssl_verify else ssl._create_unverified_context()
-            cert_file = certificate_file if ssl_verify else None
+            if ssl_verify:
+                context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH, cafile=certificate_file)
+            else:
+                context = ssl._create_unverified_context()
+
             connection = http_client.HTTPSConnection(
                 url_parsed.hostname,
                 port=url_parsed.port,
-                cert_file=cert_file,
                 context=context)
         else:
             connection = http_client.HTTPConnection(


### PR DESCRIPTION
PR to implement fix of `ssl` deprecating/removing `cert_file` in py3.11+ in favour of `context` (introduced in py3.4)